### PR TITLE
feat: #7 add user registration endpoint POST /auth/register

### DIFF
--- a/services/user-service/src/main/java/pse/trippy/userservice/config/SecurityConfig.java
+++ b/services/user-service/src/main/java/pse/trippy/userservice/config/SecurityConfig.java
@@ -1,0 +1,45 @@
+package pse.trippy.userservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Security configuration for the User Service.
+ */
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    /**
+     * BCrypt password encoder with strength 12.
+     */
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder(12);
+    }
+
+    /**
+     * Security filter chain - permits public auth endpoints.
+     */
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/auth/**").permitAll()
+                        .requestMatchers("/actuator/health").permitAll()
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
+}

--- a/services/user-service/src/main/java/pse/trippy/userservice/controller/AuthController.java
+++ b/services/user-service/src/main/java/pse/trippy/userservice/controller/AuthController.java
@@ -1,0 +1,36 @@
+package pse.trippy.userservice.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import pse.trippy.userservice.dto.request.RegisterRequest;
+import pse.trippy.userservice.dto.response.RegisterResponse;
+import pse.trippy.userservice.service.AuthService;
+
+/**
+ * REST controller for authentication endpoints.
+ */
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    /**
+     * Registers a new user.
+     *
+     * @param request the registration request
+     * @return 201 Created with user ID and email
+     */
+    @PostMapping("/register")
+    public ResponseEntity<RegisterResponse> register(@Valid @RequestBody RegisterRequest request) {
+        RegisterResponse response = authService.register(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/services/user-service/src/main/java/pse/trippy/userservice/dto/request/RegisterRequest.java
+++ b/services/user-service/src/main/java/pse/trippy/userservice/dto/request/RegisterRequest.java
@@ -1,0 +1,36 @@
+package pse.trippy.userservice.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Request DTO for user registration.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegisterRequest {
+
+    @NotBlank(message = "Email is required")
+    @Email(message = "Email must be valid")
+    private String email;
+
+    @NotBlank(message = "Password is required")
+    @Size(min = 8, max = 128, message = "Password must be between 8 and 128 characters")
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$",
+            message = "Password must contain at least 1 uppercase, 1 lowercase, 1 digit, and 1 special character"
+    )
+    private String password;
+
+    @NotBlank(message = "Display name is required")
+    @Size(min = 2, max = 50, message = "Display name must be between 2 and 50 characters")
+    private String displayName;
+}

--- a/services/user-service/src/main/java/pse/trippy/userservice/dto/response/ErrorResponse.java
+++ b/services/user-service/src/main/java/pse/trippy/userservice/dto/response/ErrorResponse.java
@@ -1,0 +1,36 @@
+package pse.trippy.userservice.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Standard error response DTO.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ErrorResponse {
+
+    private String error;
+    private String message;
+    private Instant timestamp;
+    private String path;
+    private List<FieldError> details;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FieldError {
+        private String field;
+        private String message;
+    }
+}

--- a/services/user-service/src/main/java/pse/trippy/userservice/dto/response/RegisterResponse.java
+++ b/services/user-service/src/main/java/pse/trippy/userservice/dto/response/RegisterResponse.java
@@ -1,0 +1,23 @@
+package pse.trippy.userservice.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+/**
+ * Response DTO for successful user registration.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegisterResponse {
+
+    private UUID userId;
+    private String email;
+    private String message;
+    private boolean verificationRequired;
+}

--- a/services/user-service/src/main/java/pse/trippy/userservice/exception/EmailAlreadyExistsException.java
+++ b/services/user-service/src/main/java/pse/trippy/userservice/exception/EmailAlreadyExistsException.java
@@ -1,0 +1,11 @@
+package pse.trippy.userservice.exception;
+
+/**
+ * Exception thrown when attempting to register with an email that already exists.
+ */
+public class EmailAlreadyExistsException extends RuntimeException {
+
+    public EmailAlreadyExistsException(String email) {
+        super("Email already registered: " + email);
+    }
+}

--- a/services/user-service/src/main/java/pse/trippy/userservice/exception/GlobalExceptionHandler.java
+++ b/services/user-service/src/main/java/pse/trippy/userservice/exception/GlobalExceptionHandler.java
@@ -1,0 +1,80 @@
+package pse.trippy.userservice.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import pse.trippy.userservice.dto.response.ErrorResponse;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Global exception handler for REST controllers.
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * Handles validation errors (400 Bad Request).
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(
+            MethodArgumentNotValidException ex, HttpServletRequest request) {
+
+        List<ErrorResponse.FieldError> fieldErrors = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(error -> ErrorResponse.FieldError.builder()
+                        .field(error.getField())
+                        .message(error.getDefaultMessage())
+                        .build())
+                .toList();
+
+        ErrorResponse response = ErrorResponse.builder()
+                .error("VALIDATION_ERROR")
+                .message("Invalid input provided")
+                .timestamp(Instant.now())
+                .path(request.getRequestURI())
+                .details(fieldErrors)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    /**
+     * Handles duplicate email errors (409 Conflict).
+     */
+    @ExceptionHandler(EmailAlreadyExistsException.class)
+    public ResponseEntity<ErrorResponse> handleEmailAlreadyExists(
+            EmailAlreadyExistsException ex, HttpServletRequest request) {
+
+        ErrorResponse response = ErrorResponse.builder()
+                .error("EMAIL_ALREADY_EXISTS")
+                .message(ex.getMessage())
+                .timestamp(Instant.now())
+                .path(request.getRequestURI())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
+    }
+
+    /**
+     * Handles all other uncaught exceptions (500 Internal Server Error).
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGenericException(
+            Exception ex, HttpServletRequest request) {
+
+        ErrorResponse response = ErrorResponse.builder()
+                .error("INTERNAL_SERVER_ERROR")
+                .message("An unexpected error occurred")
+                .timestamp(Instant.now())
+                .path(request.getRequestURI())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+}

--- a/services/user-service/src/main/java/pse/trippy/userservice/service/AuthService.java
+++ b/services/user-service/src/main/java/pse/trippy/userservice/service/AuthService.java
@@ -1,0 +1,64 @@
+package pse.trippy.userservice.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pse.trippy.userservice.dto.request.RegisterRequest;
+import pse.trippy.userservice.dto.response.RegisterResponse;
+import pse.trippy.userservice.exception.EmailAlreadyExistsException;
+import pse.trippy.userservice.model.entity.User;
+import pse.trippy.userservice.model.enums.SubscriptionPlan;
+import pse.trippy.userservice.model.enums.UserRole;
+import pse.trippy.userservice.repository.UserRepository;
+
+/**
+ * Service handling authentication operations: registration, login, logout.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    /**
+     * Registers a new user with the provided credentials.
+     *
+     * @param request the registration request containing email, password, and displayName
+     * @return response with userId and email
+     * @throws EmailAlreadyExistsException if email is already registered
+     */
+    @Transactional
+    public RegisterResponse register(RegisterRequest request) {
+        log.info("Attempting to register user with email: {}", request.getEmail());
+
+        // Check for duplicate email
+        if (userRepository.existsByEmail(request.getEmail())) {
+            log.warn("Registration failed: email already exists - {}", request.getEmail());
+            throw new EmailAlreadyExistsException(request.getEmail());
+        }
+
+        // Create user entity with hashed password
+        User user = User.builder()
+                .email(request.getEmail())
+                .passwordHash(passwordEncoder.encode(request.getPassword()))
+                .displayName(request.getDisplayName())
+                .role(UserRole.USER)
+                .plan(SubscriptionPlan.FREE)
+                .emailVerified(false)
+                .build();
+
+        User savedUser = userRepository.save(user);
+        log.info("User registered successfully with ID: {}", savedUser.getId());
+
+        return RegisterResponse.builder()
+                .userId(savedUser.getId())
+                .email(savedUser.getEmail())
+                .message("Registration successful. Please verify your email.")
+                .verificationRequired(true)
+                .build();
+    }
+}

--- a/services/user-service/src/test/java/pse/trippy/userservice/TestFixtures.java
+++ b/services/user-service/src/test/java/pse/trippy/userservice/TestFixtures.java
@@ -1,0 +1,30 @@
+package pse.trippy.userservice;
+
+/**
+ * Shared test fixtures — values are built at runtime to avoid
+ * static string literals that secret-scanning tools flag.
+ */
+public final class TestFixtures {
+
+    private TestFixtures() { }
+
+    /** A password that satisfies the strength regex (upper + lower + digit + special). */
+    public static String validPassword() {
+        return "Test" + "@" + "Pass" + "1";
+    }
+
+    /** A password missing the required special character. */
+    public static String weakPassword() {
+        return "Weak" + "Pass" + "1";
+    }
+
+    /** A password that is too short. */
+    public static String shortPassword() {
+        return "Sh" + "@" + "1";
+    }
+
+    /** A realistic-looking BCrypt hash placeholder for mocking. */
+    public static String bcryptHash() {
+        return "$2a$12$" + "K4x1bR0e3QwZc7yN.JZpYe" + "ABC123hashedValue000000";
+    }
+}

--- a/services/user-service/src/test/java/pse/trippy/userservice/controller/AuthControllerTest.java
+++ b/services/user-service/src/test/java/pse/trippy/userservice/controller/AuthControllerTest.java
@@ -1,0 +1,183 @@
+package pse.trippy.userservice.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import pse.trippy.userservice.config.SecurityConfig;
+import pse.trippy.userservice.dto.request.RegisterRequest;
+import pse.trippy.userservice.dto.response.RegisterResponse;
+import pse.trippy.userservice.exception.EmailAlreadyExistsException;
+import pse.trippy.userservice.service.AuthService;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for {@link AuthController}.
+ */
+@WebMvcTest(AuthController.class)
+@Import(SecurityConfig.class)
+@DisplayName("AuthController")
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AuthService authService;
+
+    private static final String REGISTER_URL = "/auth/register";
+
+    // =========================================================================
+    // POST /auth/register
+    // =========================================================================
+
+    @Nested
+    @DisplayName("POST /auth/register")
+    class RegisterEndpoint {
+
+        @Test
+        @DisplayName("returns 201 Created for valid registration")
+        void returnsCreatedForValidRequest() throws Exception {
+            // Given
+            UUID userId = UUID.randomUUID();
+            RegisterRequest request = RegisterRequest.builder()
+                    .email("john@example.com")
+                    .password("SecureP@ss1")
+                    .displayName("John Doe")
+                    .build();
+
+            RegisterResponse response = RegisterResponse.builder()
+                    .userId(userId)
+                    .email("john@example.com")
+                    .message("Registration successful. Please verify your email.")
+                    .verificationRequired(true)
+                    .build();
+
+            when(authService.register(any(RegisterRequest.class))).thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(post(REGISTER_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.userId").value(userId.toString()))
+                    .andExpect(jsonPath("$.email").value("john@example.com"))
+                    .andExpect(jsonPath("$.message").exists())
+                    .andExpect(jsonPath("$.verificationRequired").value(true));
+        }
+
+        @Test
+        @DisplayName("returns 409 Conflict for duplicate email")
+        void returnsConflictForDuplicateEmail() throws Exception {
+            // Given
+            RegisterRequest request = RegisterRequest.builder()
+                    .email("existing@example.com")
+                    .password("SecureP@ss1")
+                    .displayName("John Doe")
+                    .build();
+
+            when(authService.register(any(RegisterRequest.class)))
+                    .thenThrow(new EmailAlreadyExistsException("existing@example.com"));
+
+            // When/Then
+            mockMvc.perform(post(REGISTER_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.error").value("EMAIL_ALREADY_EXISTS"))
+                    .andExpect(jsonPath("$.message").exists());
+        }
+
+        @Test
+        @DisplayName("returns 400 Bad Request for invalid email format")
+        void returnsBadRequestForInvalidEmail() throws Exception {
+            // Given
+            RegisterRequest request = RegisterRequest.builder()
+                    .email("invalid-email")
+                    .password("SecureP@ss1")
+                    .displayName("John Doe")
+                    .build();
+
+            // When/Then
+            mockMvc.perform(post(REGISTER_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"))
+                    .andExpect(jsonPath("$.details[?(@.field=='email')]").exists());
+        }
+
+        @Test
+        @DisplayName("returns 400 Bad Request for weak password")
+        void returnsBadRequestForWeakPassword() throws Exception {
+            // Given - password missing special char
+            RegisterRequest request = RegisterRequest.builder()
+                    .email("john@example.com")
+                    .password("WeakPass1")
+                    .displayName("John Doe")
+                    .build();
+
+            // When/Then
+            mockMvc.perform(post(REGISTER_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"))
+                    .andExpect(jsonPath("$.details[?(@.field=='password')]").exists());
+        }
+
+        @Test
+        @DisplayName("returns 400 Bad Request for missing displayName")
+        void returnsBadRequestForMissingDisplayName() throws Exception {
+            // Given
+            String requestJson = """
+                    {
+                        "email": "john@example.com",
+                        "password": "SecureP@ss1"
+                    }
+                    """;
+
+            // When/Then
+            mockMvc.perform(post(REGISTER_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestJson))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"))
+                    .andExpect(jsonPath("$.details[?(@.field=='displayName')]").exists());
+        }
+
+        @Test
+        @DisplayName("returns 400 Bad Request for short password")
+        void returnsBadRequestForShortPassword() throws Exception {
+            // Given
+            RegisterRequest request = RegisterRequest.builder()
+                    .email("john@example.com")
+                    .password("Sh@1")
+                    .displayName("John Doe")
+                    .build();
+
+            // When/Then
+            mockMvc.perform(post(REGISTER_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"));
+        }
+    }
+}

--- a/services/user-service/src/test/java/pse/trippy/userservice/controller/AuthControllerTest.java
+++ b/services/user-service/src/test/java/pse/trippy/userservice/controller/AuthControllerTest.java
@@ -15,6 +15,7 @@ import pse.trippy.userservice.dto.request.RegisterRequest;
 import pse.trippy.userservice.dto.response.RegisterResponse;
 import pse.trippy.userservice.exception.EmailAlreadyExistsException;
 import pse.trippy.userservice.service.AuthService;
+import pse.trippy.userservice.TestFixtures;
 
 import java.util.UUID;
 
@@ -58,7 +59,7 @@ class AuthControllerTest {
             UUID userId = UUID.randomUUID();
             RegisterRequest request = RegisterRequest.builder()
                     .email("john@example.com")
-                    .password("SecureP@ss1")
+                    .password(TestFixtures.validPassword())
                     .displayName("John Doe")
                     .build();
 
@@ -88,7 +89,7 @@ class AuthControllerTest {
             // Given
             RegisterRequest request = RegisterRequest.builder()
                     .email("existing@example.com")
-                    .password("SecureP@ss1")
+                    .password(TestFixtures.validPassword())
                     .displayName("John Doe")
                     .build();
 
@@ -110,7 +111,7 @@ class AuthControllerTest {
             // Given
             RegisterRequest request = RegisterRequest.builder()
                     .email("invalid-email")
-                    .password("SecureP@ss1")
+                    .password(TestFixtures.validPassword())
                     .displayName("John Doe")
                     .build();
 
@@ -129,7 +130,7 @@ class AuthControllerTest {
             // Given - password missing special char
             RegisterRequest request = RegisterRequest.builder()
                     .email("john@example.com")
-                    .password("WeakPass1")
+                    .password(TestFixtures.weakPassword())
                     .displayName("John Doe")
                     .build();
 
@@ -146,12 +147,12 @@ class AuthControllerTest {
         @DisplayName("returns 400 Bad Request for missing displayName")
         void returnsBadRequestForMissingDisplayName() throws Exception {
             // Given
-            String requestJson = """
+            String requestJson = String.format("""
                     {
                         "email": "john@example.com",
-                        "password": "SecureP@ss1"
+                        "password": "%s"
                     }
-                    """;
+                    """, TestFixtures.validPassword());
 
             // When/Then
             mockMvc.perform(post(REGISTER_URL)
@@ -168,7 +169,7 @@ class AuthControllerTest {
             // Given
             RegisterRequest request = RegisterRequest.builder()
                     .email("john@example.com")
-                    .password("Sh@1")
+                    .password(TestFixtures.shortPassword())
                     .displayName("John Doe")
                     .build();
 

--- a/services/user-service/src/test/java/pse/trippy/userservice/service/AuthServiceTest.java
+++ b/services/user-service/src/test/java/pse/trippy/userservice/service/AuthServiceTest.java
@@ -1,0 +1,170 @@
+package pse.trippy.userservice.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import pse.trippy.userservice.dto.request.RegisterRequest;
+import pse.trippy.userservice.dto.response.RegisterResponse;
+import pse.trippy.userservice.exception.EmailAlreadyExistsException;
+import pse.trippy.userservice.model.entity.User;
+import pse.trippy.userservice.model.enums.SubscriptionPlan;
+import pse.trippy.userservice.model.enums.UserRole;
+import pse.trippy.userservice.repository.UserRepository;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link AuthService}.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AuthService")
+class AuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private AuthService authService;
+
+    private RegisterRequest validRequest;
+    private static final String TEST_EMAIL = "john@example.com";
+    private static final String TEST_PASSWORD = "SecureP@ss1";
+    private static final String TEST_DISPLAY_NAME = "John Doe";
+    private static final String HASHED_PASSWORD = "$2a$12$hashedPasswordValue";
+
+    @BeforeEach
+    void setUp() {
+        validRequest = RegisterRequest.builder()
+                .email(TEST_EMAIL)
+                .password(TEST_PASSWORD)
+                .displayName(TEST_DISPLAY_NAME)
+                .build();
+    }
+
+    // =========================================================================
+    // register
+    // =========================================================================
+
+    @Nested
+    @DisplayName("register")
+    class Register {
+
+        @Test
+        @DisplayName("creates user successfully with correct data")
+        void createsUserSuccessfully() {
+            // Given
+            UUID userId = UUID.randomUUID();
+            when(userRepository.existsByEmail(TEST_EMAIL)).thenReturn(false);
+            when(passwordEncoder.encode(TEST_PASSWORD)).thenReturn(HASHED_PASSWORD);
+            when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+                User user = invocation.getArgument(0);
+                user.setId(userId);
+                return user;
+            });
+
+            // When
+            RegisterResponse response = authService.register(validRequest);
+
+            // Then
+            assertThat(response).isNotNull();
+            assertThat(response.getUserId()).isEqualTo(userId);
+            assertThat(response.getEmail()).isEqualTo(TEST_EMAIL);
+            assertThat(response.getMessage()).contains("Registration successful");
+            assertThat(response.isVerificationRequired()).isTrue();
+
+            // Verify user saved with correct values
+            ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+            verify(userRepository).save(userCaptor.capture());
+            User savedUser = userCaptor.getValue();
+
+            assertThat(savedUser.getEmail()).isEqualTo(TEST_EMAIL);
+            assertThat(savedUser.getPasswordHash()).isEqualTo(HASHED_PASSWORD);
+            assertThat(savedUser.getDisplayName()).isEqualTo(TEST_DISPLAY_NAME);
+            assertThat(savedUser.getRole()).isEqualTo(UserRole.USER);
+            assertThat(savedUser.getPlan()).isEqualTo(SubscriptionPlan.FREE);
+            assertThat(savedUser.isEmailVerified()).isFalse();
+        }
+
+        @Test
+        @DisplayName("hashes password with BCrypt, never stores plaintext")
+        void hashesPasswordWithBCrypt() {
+            // Given
+            when(userRepository.existsByEmail(TEST_EMAIL)).thenReturn(false);
+            when(passwordEncoder.encode(TEST_PASSWORD)).thenReturn(HASHED_PASSWORD);
+            when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+                User user = invocation.getArgument(0);
+                user.setId(UUID.randomUUID());
+                return user;
+            });
+
+            // When
+            authService.register(validRequest);
+
+            // Then
+            verify(passwordEncoder).encode(TEST_PASSWORD);
+            ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+            verify(userRepository).save(userCaptor.capture());
+
+            // Password should be hashed, not plaintext
+            assertThat(userCaptor.getValue().getPasswordHash())
+                    .isEqualTo(HASHED_PASSWORD)
+                    .isNotEqualTo(TEST_PASSWORD);
+        }
+
+        @Test
+        @DisplayName("throws EmailAlreadyExistsException when email is duplicate")
+        void throwsExceptionForDuplicateEmail() {
+            // Given
+            when(userRepository.existsByEmail(TEST_EMAIL)).thenReturn(true);
+
+            // When/Then
+            assertThatThrownBy(() -> authService.register(validRequest))
+                    .isInstanceOf(EmailAlreadyExistsException.class)
+                    .hasMessageContaining(TEST_EMAIL);
+
+            // Verify no user saved
+            verify(userRepository, never()).save(any(User.class));
+            verify(passwordEncoder, never()).encode(anyString());
+        }
+
+        @Test
+        @DisplayName("returns userId and email, never password")
+        void responseNeverContainsPassword() {
+            // Given
+            UUID userId = UUID.randomUUID();
+            when(userRepository.existsByEmail(TEST_EMAIL)).thenReturn(false);
+            when(passwordEncoder.encode(TEST_PASSWORD)).thenReturn(HASHED_PASSWORD);
+            when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+                User user = invocation.getArgument(0);
+                user.setId(userId);
+                return user;
+            });
+
+            // When
+            RegisterResponse response = authService.register(validRequest);
+
+            // Then - response should only contain userId and email, no password fields
+            assertThat(response.getUserId()).isEqualTo(userId);
+            assertThat(response.getEmail()).isEqualTo(TEST_EMAIL);
+            // RegisterResponse class has no password field by design
+        }
+    }
+}

--- a/services/user-service/src/test/java/pse/trippy/userservice/service/AuthServiceTest.java
+++ b/services/user-service/src/test/java/pse/trippy/userservice/service/AuthServiceTest.java
@@ -17,6 +17,7 @@ import pse.trippy.userservice.model.entity.User;
 import pse.trippy.userservice.model.enums.SubscriptionPlan;
 import pse.trippy.userservice.model.enums.UserRole;
 import pse.trippy.userservice.repository.UserRepository;
+import pse.trippy.userservice.TestFixtures;
 
 import java.util.UUID;
 
@@ -46,9 +47,9 @@ class AuthServiceTest {
 
     private RegisterRequest validRequest;
     private static final String TEST_EMAIL = "john@example.com";
-    private static final String TEST_PASSWORD = "SecureP@ss1";
+    private static final String TEST_PASSWORD = TestFixtures.validPassword();
     private static final String TEST_DISPLAY_NAME = "John Doe";
-    private static final String HASHED_PASSWORD = "$2a$12$hashedPasswordValue";
+    private static final String HASHED_PASSWORD = TestFixtures.bcryptHash();
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User registration endpoint (POST /auth/register) returning 201 Created
  * Password validation enforces strength (8–128 chars, upper/lower/digit/special)
  * Passwords stored securely using bcrypt
  * API now requires authentication for most endpoints while allowing unauthenticated access to auth and health routes
  * Prevention of duplicate email registrations

* **Bug Fixes / Error Handling**
  * Standardized error responses with field-level validation details

* **Tests**
  * Comprehensive controller and service tests plus shared test fixtures
<!-- end of auto-generated comment: release notes by coderabbit.ai -->