### PR TITLE
Fix(gateway): Update lombok and add surefire argLine for JWT test sup…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <spring-cloud.version>2024.0.0</spring-cloud.version>
 
         <!-- Common Dependencies Versions -->
-        <lombok.version>1.18.34</lombok.version>
+        <lombok.version>1.18.42</lombok.version>
         <mapstruct.version>1.6.3</mapstruct.version>
         <springdoc-openapi.version>2.7.0</springdoc-openapi.version>
         <postgresql.version>42.7.3</postgresql.version>
@@ -150,6 +150,13 @@
                                 <version>${mapstruct.version}</version>
                             </path>
                         </annotationProcessorPaths>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <argLine>-Dnet.bytebuddy.experimental=true</argLine>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
- Updated Lombok from 1.18.34 to 1.18.42 for improved JDK compatibility and annotation processing support
- Added Maven Surefire plugin configuration with ByteBuddy experimental flag
- Enabled stable execution of JWT and security-related tests during Maven builds
- Improved compatibility for mocking/instrumentation used in test environments