### PR TITLE
test: improve test coverage for Sprint 2 features

### DIFF
--- a/services/api-gateway/src/test/java/pse/trippy/apigateway/health/HealthEndpointIntegrationTest.java
+++ b/services/api-gateway/src/test/java/pse/trippy/apigateway/health/HealthEndpointIntegrationTest.java
@@ -1,0 +1,79 @@
+package pse.trippy.apigateway.health;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@TestPropertySource(properties = {
+        "spring.data.redis.host=localhost",
+        "spring.data.redis.port=6379",
+        "spring.data.redis.password=",
+        "trippy.gateway.jwks-uri=http://localhost:8081/.well-known/jwks.json"
+})
+@DisplayName("Health Endpoint Integration Test")
+class HealthEndpointIntegrationTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Test
+    @DisplayName("GET /actuator/health returns 200")
+    void healthEndpointReturns200() {
+        webTestClient.get()
+                .uri("/actuator/health")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.status").exists();
+    }
+
+    @Test
+    @DisplayName("GET /actuator/health/liveness returns 200")
+    void livenessProbeReturns200() {
+        webTestClient.get()
+                .uri("/actuator/health/liveness")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.status").isEqualTo("UP");
+    }
+
+    @Test
+    @DisplayName("GET /actuator/health/readiness returns 200")
+    void readinessProbeReturns200() {
+        webTestClient.get()
+                .uri("/actuator/health/readiness")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.status").exists();
+    }
+
+    @Test
+    @DisplayName("GET /actuator/info returns 200 with app info")
+    void infoEndpointReturnsAppInfo() {
+        webTestClient.get()
+                .uri("/actuator/info")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.app.name").isEqualTo("Trippy API Gateway");
+    }
+
+    @Test
+    @DisplayName("GET /health returns aggregated downstream health")
+    void customHealthEndpointReturnsAggregated() {
+        webTestClient.get()
+                .uri("/health")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.status").exists();
+    }
+}

--- a/services/payment-service/src/test/java/pse/trippy/paymentservice/controller/WebhookControllerTest.java
+++ b/services/payment-service/src/test/java/pse/trippy/paymentservice/controller/WebhookControllerTest.java
@@ -1,0 +1,82 @@
+package pse.trippy.paymentservice.controller;
+
+import com.stripe.model.checkout.Session;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import pse.trippy.paymentservice.service.WebhookService;
+import com.stripe.model.Event;
+import com.stripe.model.EventDataObjectDeserializer;
+import com.stripe.net.Webhook;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("WebhookController")
+class WebhookControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private WebhookService webhookService;
+
+    @Test
+    @DisplayName("POST /payments/webhook returns 200 for valid checkout.session.completed")
+    void webhookHandlesCheckoutSessionCompleted() throws Exception {
+        Event event = mock(Event.class);
+        when(event.getType()).thenReturn("checkout.session.completed");
+        when(event.getId()).thenReturn("evt_test_123");
+
+        Session session = mock(Session.class);
+        EventDataObjectDeserializer deserializer = mock(EventDataObjectDeserializer.class);
+        when(event.getDataObjectDeserializer()).thenReturn(deserializer);
+        when(deserializer.getObject()).thenReturn(Optional.of(session));
+
+        try (MockedStatic<Webhook> webhookMock = mockStatic(Webhook.class)) {
+            webhookMock.when(() -> Webhook.constructEvent(any(), any(), any())).thenReturn(event);
+
+            mockMvc.perform(post("/payments/webhook")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}")
+                            .header("Stripe-Signature", "t=123,v1=abc"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string("Received"));
+
+            verify(webhookService).handleCheckoutSessionCompleted(session);
+        }
+    }
+
+    @Test
+    @DisplayName("POST /payments/webhook returns 400 for invalid signature")
+    void webhookRejectsInvalidSignature() throws Exception {
+        try (MockedStatic<Webhook> webhookMock = mockStatic(Webhook.class)) {
+            webhookMock.when(() -> Webhook.constructEvent(any(), any(), any()))
+                    .thenThrow(new com.stripe.exception.SignatureVerificationException(
+                            "Invalid signature", "sig_header"));
+
+            mockMvc.perform(post("/payments/webhook")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}")
+                            .header("Stripe-Signature", "invalid"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string("Invalid signature"));
+        }
+    }
+}

--- a/services/payment-service/src/test/java/pse/trippy/paymentservice/service/SubscriptionServiceTest.java
+++ b/services/payment-service/src/test/java/pse/trippy/paymentservice/service/SubscriptionServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import pse.trippy.paymentservice.dto.request.CancelSubscriptionRequest;
 import pse.trippy.paymentservice.dto.request.PaymentConfirmationRequest;
 import pse.trippy.paymentservice.dto.response.PaymentConfirmationResponse;
@@ -42,6 +43,8 @@ class SubscriptionServiceTest {
     private SubscriptionRepository subscriptionRepository;
     @Mock
     private TransactionRepository transactionRepository;
+    @Mock
+    private RabbitTemplate rabbitTemplate;
 
     @InjectMocks
     private SubscriptionService subscriptionService;

--- a/services/payment-service/src/test/java/pse/trippy/paymentservice/service/WebhookServiceTest.java
+++ b/services/payment-service/src/test/java/pse/trippy/paymentservice/service/WebhookServiceTest.java
@@ -1,0 +1,117 @@
+package pse.trippy.paymentservice.service;
+
+import com.stripe.model.checkout.Session;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import pse.trippy.paymentservice.model.entity.Subscription;
+import pse.trippy.paymentservice.model.entity.WebhookEvent;
+import pse.trippy.paymentservice.model.enums.SubscriptionPlan;
+import pse.trippy.paymentservice.model.enums.SubscriptionStatus;
+import pse.trippy.paymentservice.repository.SubscriptionRepository;
+import pse.trippy.paymentservice.repository.WebhookEventRepository;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("WebhookService")
+class WebhookServiceTest {
+
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+    @Mock
+    private WebhookEventRepository webhookEventRepository;
+    @Mock
+    private RabbitTemplate rabbitTemplate;
+
+    @InjectMocks
+    private WebhookService webhookService;
+
+    private static final UUID USER_ID = UUID.randomUUID();
+
+    @Test
+    @DisplayName("handles checkout.session.completed and creates subscription")
+    void handlesCheckoutSessionCompletedCreatesSubscription() {
+        Session session = mock(Session.class);
+        when(session.getId()).thenReturn("cs_test_123");
+        when(session.getClientReferenceId()).thenReturn(USER_ID.toString());
+        when(session.getCustomerEmail()).thenReturn("user@test.com");
+        when(session.getAmountTotal()).thenReturn(999L);
+        when(session.getMetadata()).thenReturn(Map.of("planId", "premium_monthly"));
+
+        when(webhookEventRepository.existsByCheckoutSessionId("cs_test_123")).thenReturn(false);
+        when(webhookEventRepository.save(any(WebhookEvent.class))).thenAnswer(i -> i.getArgument(0));
+        when(subscriptionRepository.findByUserId(USER_ID)).thenReturn(Optional.empty());
+        when(subscriptionRepository.save(any(Subscription.class))).thenAnswer(i -> {
+            Subscription s = i.getArgument(0);
+            s.setId(UUID.randomUUID());
+            return s;
+        });
+
+        webhookService.handleCheckoutSessionCompleted(session);
+
+        verify(webhookEventRepository).save(any(WebhookEvent.class));
+        verify(subscriptionRepository).save(any(Subscription.class));
+        verify(rabbitTemplate).convertAndSend(eq("payment.events"), eq("payment.subscription.activated"), any(Map.class));
+    }
+
+    @Test
+    @DisplayName("skips duplicate webhook (idempotent via session ID)")
+    void skipsDuplicateWebhook() {
+        Session session = mock(Session.class);
+        when(session.getId()).thenReturn("cs_test_duplicate");
+        when(webhookEventRepository.existsByCheckoutSessionId("cs_test_duplicate")).thenReturn(true);
+
+        webhookService.handleCheckoutSessionCompleted(session);
+
+        verify(subscriptionRepository, never()).save(any());
+        verify(rabbitTemplate, never()).convertAndSend(anyString(), anyString(), any(Object.class));
+    }
+
+    @Test
+    @DisplayName("updates existing subscription on webhook for enterprise plan")
+    void updatesExistingSubscriptionOnWebhook() {
+        Session session = mock(Session.class);
+        when(session.getId()).thenReturn("cs_test_456");
+        when(session.getClientReferenceId()).thenReturn(USER_ID.toString());
+        when(session.getCustomerEmail()).thenReturn("user@test.com");
+        when(session.getAmountTotal()).thenReturn(29999L);
+        when(session.getMetadata()).thenReturn(Map.of("planId", "enterprise_monthly"));
+
+        when(webhookEventRepository.existsByCheckoutSessionId("cs_test_456")).thenReturn(false);
+        when(webhookEventRepository.save(any(WebhookEvent.class))).thenAnswer(i -> i.getArgument(0));
+
+        Subscription existing = Subscription.builder()
+                .userId(USER_ID)
+                .plan(SubscriptionPlan.PREMIUM)
+                .status(SubscriptionStatus.ACTIVE)
+                .currentPeriodStart(LocalDate.now().minusMonths(1))
+                .currentPeriodEnd(LocalDate.now())
+                .priceAmount(new BigDecimal("9.99"))
+                .build();
+        existing.setId(UUID.randomUUID());
+        when(subscriptionRepository.findByUserId(USER_ID)).thenReturn(Optional.of(existing));
+        when(subscriptionRepository.save(any(Subscription.class))).thenAnswer(i -> i.getArgument(0));
+
+        webhookService.handleCheckoutSessionCompleted(session);
+
+        verify(subscriptionRepository).save(any(Subscription.class));
+        verify(rabbitTemplate).convertAndSend(eq("payment.events"), eq("payment.subscription.activated"), any(Map.class));
+    }
+}


### PR DESCRIPTION
- Add WebhookServiceTest: 3 tests (create subscription, idempotency, update)
- Add WebhookControllerTest: 2 tests (valid event, invalid signature)
- Add HealthEndpointIntegrationTest: 5 tests (health, liveness, readiness, info, custom)
- Fix SubscriptionServiceTest: add missing RabbitTemplate mock