### PR TITLE
fix(user-service): add @EnableJpaRepositories to fix JPA/Redis repo conflict

### DIFF
--- a/services/user-service/src/main/java/pse/trippy/userservice/UserServiceApplication.java
+++ b/services/user-service/src/main/java/pse/trippy/userservice/UserServiceApplication.java
@@ -2,8 +2,12 @@ package pse.trippy.userservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 
 @SpringBootApplication
+@EnableJpaRepositories(basePackages = "pse.trippy.userservice.repository")
+@EnableRedisRepositories(basePackages = {})
 public class UserServiceApplication {
     public static void main(String[] args) {
         SpringApplication.run(UserServiceApplication.class, args);

--- a/services/user-service/src/main/java/pse/trippy/userservice/UserServiceApplication.java
+++ b/services/user-service/src/main/java/pse/trippy/userservice/UserServiceApplication.java
@@ -3,11 +3,9 @@ package pse.trippy.userservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 
 @SpringBootApplication
 @EnableJpaRepositories(basePackages = "pse.trippy.userservice.repository")
-@EnableRedisRepositories(basePackages = {})
 public class UserServiceApplication {
     public static void main(String[] args) {
         SpringApplication.run(UserServiceApplication.class, args);


### PR DESCRIPTION
## Summary
Fixes the JPA/Redis repository conflict that prevented the user-service from starting when both Spring Data JPA and Spring Data Redis repositories are present in the same application context.

## Changes
- Added `@EnableJpaRepositories(basePackages = "pse.trippy.userservice.repository")` to `UserServiceApplication` to explicitly scope JPA repository scanning and avoid ambiguity with Redis repositories.

## Related
- Resolves startup failure when both `RefreshTokenRepository` (JPA) and Redis-backed `TokenBlacklistService` are active.